### PR TITLE
feat: display overlapping events in the calendar

### DIFF
--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -145,7 +145,7 @@
 				{#if current[idxw][idxd] != 0}
 					<span class="date" class:today={isToday(current[idxw][idxd])}>
 						{ current[idxw][idxd] }
-						{#each (getEventsOnDay($eventStore, current[idxw][idxd])) as ev}
+						{#each (getEventsOnDay($eventStore, current[idxw][idxd]).slice(0, 3)) as ev}
 							<div class="eventdisplay"
 							on:keydown
 							on:click={() => { 
@@ -155,6 +155,14 @@
 							{ ev != null ? ev.name : ''}
 							</div>
 						{/each}
+						{#if (getEventsOnDay($eventStore, current[idxw][idxd]).length) > 3}
+							<div class="see-more"
+							on:keydown
+							on:click={() => {
+								showDayEventsModal = true;
+								dayToExpand = new Date(year, month, current[idxw][idxd]);
+							}}> See more... </div>
+						{/if}
 					</span>
 				{:else if (idxw < 1)}
 					<span class="date other">{ prev[prev.length - 1][idxd] }</span>
@@ -258,4 +266,16 @@
 	.eventdisplay:hover {
 		color: #60bfac;
 	}
+
+	.see-more {
+		font-style: italic;
+		font-weight: lighter;
+		color: grey;
+	}
+
+	.see-more:hover {
+		color: rgb(169, 168, 168);
+		user-select: none;
+	}
+
 </style>

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -145,13 +145,16 @@
 				{#if current[idxw][idxd] != 0}
 					<span class="date" class:today={isToday(current[idxw][idxd])}>
 						{ current[idxw][idxd] }
-						<div class="eventdisplay" on:keydown
+						{#each (getEventsOnDay($eventStore, current[idxw][idxd])) as ev}
+							<div class="eventdisplay"
+							on:keydown
 							on:click={() => { 
 								showViewEventModal = true;
-								eventToView = displayEvent($eventStore, current[idxw][idxd]);
+								eventToView = ev;
 								}}>
-							{ displayEvent($eventStore, current[idxw][idxd]) != null ? displayEvent($eventStore, current[idxw][idxd]).name : ''}
-						</div>
+							{ ev != null ? ev.name : ''}
+							</div>
+						{/each}
 					</span>
 				{:else if (idxw < 1)}
 					<span class="date other">{ prev[prev.length - 1][idxd] }</span>

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -7,6 +7,7 @@
 	import DialogBox from '../global-components/DialogBox.svelte';
 	import GotoDateForm from './GotoDateForm.svelte';
 	import EditEventForm from './EditEventForm.svelte';
+	import { timeAscending } from './timeAscending';
 	import { isInRange } from '../isInRange';
 
 	export let today = new Date();
@@ -74,6 +75,7 @@
 				eventsOnDay.push(e);
 			}
 		}
+		eventsOnDay = eventsOnDay.sort(timeAscending);
 		return eventsOnDay;
 	}
 	

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -26,13 +26,22 @@
 	let next = calendarize(new Date(year, month+1), offset);
 
 	let viewEventDialog: HTMLDialogElement;
+	let viewDayEventsDialog: HTMLDialogElement;
 	let gotoDateDialog: HTMLDialogElement;
 	let editEventDialog: HTMLDialogElement;
+	let showDayEventsModal: boolean = false;
 	let showViewEventModal: boolean = false;
 	let showGotoDateModal: boolean = false;
 	let showEditEventModal: boolean = false;
 
 	// let displayWidth = 0;
+	let dayToExpand: Date;
+	let dateDisplayOptions = {
+		month: "long",
+		day: "2-digit",
+		year: "numeric",
+	};
+
 	let eventToView: Event | null = null;
 	function getEventsOnDay(allEvents: Event[], day) {
 		let eventsOnDay: Event[] | null = [];
@@ -192,6 +201,25 @@
 				<EditEventForm slot="contents" bind:event={eventToView} on:editExistingEvent={editEvent} />
 			</DialogBox>
 			<button style="position: relative; right: 2em;" on:click={deleteEvent}>Delete</button>
+		</div>
+		
+	</DialogBox>
+{/if}
+
+{#if dayToExpand !== undefined }
+	<DialogBox bind:showModal={showDayEventsModal} bind:dialog={viewDayEventsDialog}>
+		<h2 slot="header" class="pop-up">Events on { dayToExpand.toLocaleDateString("en-US", dateDisplayOptions) }</h2>
+		<div slot="contents">
+			{#each getEventsOnDay($eventStore, dayToExpand.getDate()) as ev}
+				<div class="eventdisplay"
+				on:keydown
+				on:click={() => {
+					showViewEventModal = true;
+					eventToView = ev;
+					}}>
+				{ ev.name }
+				</div>
+			{/each}
 		</div>
 		
 	</DialogBox>

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -41,6 +41,12 @@
 		day: "2-digit",
 		year: "numeric",
 	};
+	let timeDisplayOptions = {
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: true,
+
+	}
 
 	let eventToView: Event | null = null;
 	function getEventsOnDay(allEvents: Event[], day) {
@@ -211,14 +217,16 @@
 		<h2 slot="header" class="pop-up">Events on { dayToExpand.toLocaleDateString("en-US", dateDisplayOptions) }</h2>
 		<div slot="contents">
 			{#each getEventsOnDay($eventStore, dayToExpand.getDate()) as ev}
-				<div class="eventdisplay"
-				on:keydown
-				on:click={() => {
-					showViewEventModal = true;
-					eventToView = ev;
-					}}>
-				{ ev.name }
-				</div>
+				<li>
+					<span class="clickable-li" style="user-select:none"
+					on:keydown
+					on:click={() => {
+						showViewEventModal = true;
+						eventToView = ev;
+						}}>
+					{new Date(ev.startTime).toLocaleTimeString("en-US", timeDisplayOptions)} — { ev.name }
+					</span>
+				</li>
 			{/each}
 		</div>
 		
@@ -264,7 +272,6 @@
 	
 	.date {
 		min-height: 85px;
-		display: table;
 		font-size: 16px;
 		letter-spacing: -1px;
 		border: 1px solid #e6e4e4;
@@ -283,10 +290,12 @@
 	}
 
 	.eventdisplay {
-		display: table-row;
+		display: grid;
+		margin: 1.75px;
 		font-weight: 600;
 		text-align: center;
 		color: #1c8d76;
+		background-color: white;
 		border-radius: 4px;
 		user-select: none;
 	}
@@ -304,6 +313,10 @@
 	.see-more:hover {
 		color: rgb(169, 168, 168);
 		user-select: none;
+	}
+
+	.clickable-li:hover {
+		color: rgb(169, 168, 168);
 	}
 
 </style>

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -28,8 +28,12 @@
 	let viewEventDialog: HTMLDialogElement;
 	let gotoDateDialog: HTMLDialogElement;
 	let editEventDialog: HTMLDialogElement;
+	let showViewEventModal: boolean = false;
+	let showGotoDateModal: boolean = false;
+	let showEditEventModal: boolean = false;
 
 	// let displayWidth = 0;
+	let eventToView: Event | null = null;
 	function getEventsOnDay(allEvents: Event[], day) {
 		let eventsOnDay: Event[] | null = [];
 
@@ -58,13 +62,6 @@
 		return eventsOnDay;
 	}
 	
-	let showViewEventModal = false;
-	let eventToView: Event | null = null;
-	let showEditEventModal: boolean = false;
-	let showGotoDateModal: boolean = false;
-	let gotoMonth: number = 0;
-	let gotoYear: number = today.getFullYear();
-
 	function toPrev() {
 		[current, next] = [prev, current];
 		
@@ -86,6 +83,9 @@
 		
 		next = calendarize(new Date(year, month+1), offset);
 	}
+
+	let gotoMonth: number = 0;
+	let gotoYear: number = today.getFullYear();
 
 	function toDate(gotoMonth, gotoYear) {
 		month = gotoMonth;

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -227,7 +227,8 @@
 	}
 	
 	.date {
-		height: 50px;
+		min-height: 85px;
+		display: table;
 		font-size: 16px;
 		letter-spacing: -1px;
 		border: 1px solid #e6e4e4;
@@ -246,6 +247,7 @@
 	}
 
 	.eventdisplay {
+		display: table-row;
 		font-weight: 600;
 		text-align: center;
 		color: #1c8d76;

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -29,8 +29,11 @@
 	let gotoDateDialog: HTMLDialogElement;
 	let editEventDialog: HTMLDialogElement;
 
-	function displayEvent(events: Event[], day) {
-		for (const e of events) {
+	// let displayWidth = 0;
+	function getEventsOnDay(allEvents: Event[], day) {
+		let eventsOnDay: Event[] | null = [];
+
+		for (const e of allEvents) {
 			const start = new Date(e.startTime);
 			const startYr = start.getFullYear();
 			const startMth = start.getMonth()+1;
@@ -43,15 +46,16 @@
 				const endMth = end.getMonth()+1;
 				const endDay = end.getDate();
 				if (isInRange(year, startYr, endYr) && isInRange(month+1, startMth, endMth) && isInRange(day, startDay, endDay)) {
-					return e;
+					eventsOnDay.push(e);
 				}
 			}
 			// Display a one-day event
-			if (startYr == year && startMth == month+1 && startDay == day) {
-				return e;
+			else if (startYr == year && startMth == month+1 && startDay == day) {
+				// displayWidth = (new Date(e.endTime).getDate() - startDay) + 1;
+				eventsOnDay.push(e);
 			}
 		}
-		return null;
+		return eventsOnDay;
 	}
 	
 	let showViewEventModal = false;

--- a/src/renderer/src/lib/calendar/Calendar.svelte
+++ b/src/renderer/src/lib/calendar/Calendar.svelte
@@ -117,10 +117,6 @@
     }
 </script>
 
-<!-- <div>
-	<EventsDropdown />
-</div> -->
-
 <header>
 	<Arrow left on:click={toPrev} />
 	<!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -139,9 +135,9 @@
 		<span class="label">{ labels[(idx + offset) % 7] }</span>
 	{/each}
 
-	{#each { length:6 } as w,idxw (idxw)}
+	{#each { length:6 } as _,idxw (idxw)}
 		{#if current[idxw]}
-			{#each { length:7 } as d,idxd (idxd)}
+			{#each { length:7 } as _,idxd (idxd)}
 				{#if current[idxw][idxd] != 0}
 					<span class="date" class:today={isToday(current[idxw][idxd])}>
 						{ current[idxw][idxd] }
@@ -228,7 +224,6 @@
 		font-size: 16px;
 		letter-spacing: -1px;
 		border: 1px solid #e6e4e4;
-		padding-right: 4px;
 		font-weight: 700;
 		padding: 0.5rem;
 	}
@@ -247,6 +242,7 @@
 		font-weight: 600;
 		text-align: center;
 		color: #1c8d76;
+		border-radius: 4px;
 		user-select: none;
 	}
 

--- a/src/renderer/src/lib/calendar/timeAscending.ts
+++ b/src/renderer/src/lib/calendar/timeAscending.ts
@@ -1,0 +1,14 @@
+import type { Event } from '../../types/event';
+
+export function timeAscending(a: Event, b: Event){
+    const dateA = new Date(a.startTime);
+    const dateB = new Date(b.startTime);
+    
+    if (dateA < dateB) {
+        return -1;
+    }
+    if (dateA > dateB) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## ✨Merging the `multiple-events` feature branch to `main`
### Displaying a day's events
- function to fetch events on a given day now returns a list
- displayed events are sorted by ascending time
- on a day with three events, add a "See More" button that opens up a dialog box containing all the day's events

### Minor styling
- clickable event boxes with hover styles

### Next to implement
- an event should ideally be one whole "box" that expands across the calendar based on the duration