### PR TITLE
fix: new emoji selector

### DIFF
--- a/src/renderer/src/lib/notes/EmojiPicker.svelte
+++ b/src/renderer/src/lib/notes/EmojiPicker.svelte
@@ -1,0 +1,21 @@
+<script>
+    import { EmojiButton } from "@joeattardi/emoji-button";
+    import { createEventDispatcher } from "svelte";
+  
+    const dispatch = createEventDispatcher();
+  
+    const picker = new EmojiButton();
+    let trigger;
+  
+    picker.on("emoji", selection => {
+      dispatch("change", selection);
+    });
+  
+    function togglePicker() {
+      picker.togglePicker(trigger);
+    }
+  </script>
+  
+  <button type="button" bind:this={trigger} on:click={togglePicker}>
+    😀
+  </button>

--- a/src/renderer/src/lib/notes/addnoteForm.svelte
+++ b/src/renderer/src/lib/notes/addnoteForm.svelte
@@ -3,7 +3,7 @@
     import type { Note } from "../../types/note";
     import { createEventDispatcher } from "svelte";
     import Button from "./Button.svelte";
-    import EmojiSelector from 'svelte-emoji-selector';
+    import EmojiPicker from "./EmojiPicker.svelte";
 
     let dispatch = createEventDispatcher();
 
@@ -12,8 +12,6 @@
 
     let valid = false;
     let errors = { inTitle: '', inNoteContent: ''};
-
-    const autoClose = false;
 
     const handleSubmit = () => {
         valid = true;
@@ -50,14 +48,14 @@
         }
     };
 
-    function emojiOnTitle(event) {
-        title += event.detail
+    function onEmojiChange_title(event) {
+        title = (title).concat(event.detail.emoji);
     }
 
-    function emojiOnNote(event) {
-        noteContent += event.detail
+    function onEmojiChange_text(event) {
+        noteContent = (noteContent).concat(event.detail.emoji);
     }
-
+    
     let words = 0;
     $: if (noteContent.trim().length > 0) {
         words = noteContent.trim().split(' ').length;
@@ -65,13 +63,14 @@
 </script>
 
 <h3> Add a new note </h3>
-<EmojiSelector on:emoji={emojiOnTitle} {autoClose} />
-<EmojiSelector on:emoji={emojiOnNote} {autoClose}/>
 <form on:submit|preventDefault={handleSubmit}>
     <input type="text" placeholder="Title" bind:value={title}>
+    <EmojiPicker on:change={onEmojiChange_title}/>
     
     <div class="errors"> { errors.inTitle }</div>
-    <textarea placeholder= "Type your note" cols="30" rows="10" bind:value={noteContent}></textarea><br>
+    <textarea placeholder= "Type your note" cols="30" rows="10" bind:value={noteContent}></textarea>
+    <br>
+    <EmojiPicker on:change={onEmojiChange_text}/>
     
     <div class="errors">{ errors.inNoteContent }</div>
     <br>

--- a/src/renderer/src/lib/notes/editNoteForm.svelte
+++ b/src/renderer/src/lib/notes/editNoteForm.svelte
@@ -3,13 +3,12 @@
     import type { Note } from "../../types/note";
     import { createEventDispatcher } from "svelte";
     import Button from "./Button.svelte";
-    import EmojiSelector from 'svelte-emoji-selector';
+    import EmojiPicker from "./EmojiPicker.svelte";
 
     export let selectedNote: Note;
 
     let dispatch = createEventDispatcher();
 
-    const autoClose = false;
     const handleEdit = () => {
         NotesStore.update(currentNotes => {
             let copiedNotes: Note[] = [...currentNotes];
@@ -26,12 +25,13 @@
     function togglePin(noteToPin) {
         noteToPin.pinned = !noteToPin.pinned;
     }
-    function emojiOnTitle(event) {
-        selectedNote.title += event.detail
+
+    function onEmojiChange_title(event) {
+        selectedNote.title = (selectedNote.title).concat(event.detail.emoji);
     }
 
-    function emojiOnNote(event) {
-        selectedNote.noteContent += event.detail
+    function onEmojiChange_text(event) {
+        selectedNote.noteContent = (selectedNote.noteContent).concat(event.detail.emoji);
     }
 
     let words = 0;
@@ -43,14 +43,16 @@
 </script>
 
 <h3> Edit Note </h3>
-<EmojiSelector on:emoji={emojiOnTitle} {autoClose} />
-<EmojiSelector on:emoji={emojiOnNote} {autoClose}/>
-<button type="button" on:click={() => togglePin(selectedNote)}>Toggle pin</button>
+
 
 <form on:submit|preventDefault={handleEdit}>
     <input type="text" placeholder="Title" bind:value={selectedNote.title}>
+    <EmojiPicker on:change={onEmojiChange_title}/>
+    <button type="button" on:click={() => togglePin(selectedNote)}>📌</button>
     
-    <textarea placeholder= "Type your note" cols="30" rows="10" bind:value={selectedNote.noteContent}></textarea><br>
+    <textarea placeholder= "Type your note" cols="30" rows="10" bind:value={selectedNote.noteContent}></textarea>
+    <br>
+    <EmojiPicker on:change={onEmojiChange_text}/>
     
     <br>
     <div>


### PR DESCRIPTION
# New emoji selector for notes
Now uses a JavaScript library [Emoji Button](https://emoji-button.js.org/). Instead of importing a Svelte component from an external dependency, this introduces a new file `EmojiPicker.svelte` which could allow modifying behavior directly. (For instance, changing what the button looks like).

## Installation
```
npm i @joeattardi/emoji-button
npm uninstall svelte-emoji-selector
```

## ❗ Note
Currently allows only one emoji to be added at a time.